### PR TITLE
Gg solo spike

### DIFF
--- a/app/controllers/discover_controller.rb
+++ b/app/controllers/discover_controller.rb
@@ -1,5 +1,13 @@
 # frozen_string_literal: true
 
 class DiscoverController < ApplicationController
+  before_action :find_user
+
   def index; end
+
+  private
+
+  def find_user
+    @user = User.find(params[:user_id])
+  end
 end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class MoviesController < ApplicationController
+  def index; end
+end

--- a/app/views/discover/index.html.erb
+++ b/app/views/discover/index.html.erb
@@ -1,0 +1,11 @@
+<div class='top-movies'>
+  <%= button_to 'Find Top Rated Movies', user_movies_path(@user), method: :get, params: { q: 'top 20rated' } %>
+</div>
+<br>
+<div class='search-movies'>
+  <%= form_with url: user_movies_path(@user), method: :get, local: true do |f| %>
+    <%= f.label :q, "Search:" %>
+    <%= f.text_field :q %>
+    <%= f.submit "Find Movies" %>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,5 +11,6 @@ Rails.application.routes.draw do
 
   resources :users, only: %i[new create show] do
     resources :discover, only: %i[index]
+    resources :movies, only: %i[index]
   end
 end

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -15,5 +15,5 @@
 Commit Message ...
 
 
-Co-authored-by: Michael Callahan <mcalla242@gmail.com>
-Co-authored-by: Garrett Gregor <garrett.gregor@gmail.com>
+Co-authored-by: Michael Callahan <calforcal@users.noreply.github.com>
+Co-authored-by: Garrett Gregor <118634754+garrettgregor@users.noreply.github.com>

--- a/spec/features/users/discover/index_spec.rb
+++ b/spec/features/users/discover/index_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe '/user/:id/discover', type: :feature do
+  describe 'discover page' do
+    let!(:user1) { User.create!(name: 'Michael', email: 'mcalla123@gmail.com') }
+    let!(:user2) { User.create!(name: 'Garrett', email: 'garrett123@gmail.com') }
+
+    before(:each) do
+      visit user_discover_index_path(user1)
+    end
+
+    it 'has a button to discover top rated movies' do
+      within '.top-movies' do
+        click_button('Find Top Rated Movies')
+        expect(current_path).to eq(user_movies_path(user1))
+      end
+    end
+
+    it 'has a text field to enter keyworkd(s) to search by movie title' do
+      within '.search-movies' do
+        fill_in('Search:', with: 'Fight Club')
+      end
+    end
+
+    it 'has a button to search by movie title' do
+      within '.search-movies' do
+        fill_in('Search:', with: 'Fight Club')
+        click_button('Find Movies')
+        expect(current_path).to eq(user_movies_path(user1))
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Describe your changes
All functionality from User Story 5 Complete
```
As a user,
When I visit the '/users/:id/discover' path, where :id, is the id of a valid user,
I see

 A Button to Discover Top Rated Movies
 A text field to enter keyword(s) to search by movie title
 A Button to Search by Movie Title

When the user clicks on the Top Rated Movies OR the search button, they are taken to the movies results page

The movies will be retrieved by consuming [The MovieDB API](https://developers.themoviedb.org/3/getting-started/introduction)
```

## Issue ticket number and link
Closes #11 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] Will this be part of a product update? This will update search functionality before consuming API.

## Test Coverage @ 100% 🏅 

```zsh
garrettgregor ~/turing_work/3mod/projects/viewing_party_lite_7 [gg-solo-spike] $ ber
.......................

Finished in 0.53988 seconds (files took 1.44 seconds to load)
23 examples, 0 failures

Coverage report generated for RSpec to /Users/garrettgregor/turing_work/3mod/projects/viewing_party_lite_7/coverage. 179 / 179 LOC (100.0%) covered.
garrettgregor ~/turing_work/3mod/projects/viewing_party_lite_7 [gg-solo-spike] $ berf
..............

Finished in 0.38922 seconds (files took 1.1 seconds to load)
14 examples, 0 failures

Coverage report generated for RSpec to /Users/garrettgregor/turing_work/3mod/projects/viewing_party_lite_7/coverage. 154 / 154 LOC (100.0%) covered.
garrettgregor ~/turing_work/3mod/projects/viewing_party_lite_7 [gg-solo-spike] $ berm
.........

Finished in 0.11056 seconds (files took 1.18 seconds to load)
9 examples, 0 failures

Coverage report generated for RSpec to /Users/garrettgregor/turing_work/3mod/projects/viewing_party_lite_7/coverage. 76 / 76 LOC (100.0%) covered.
garrettgregor ~/turing_work/3mod/projects/viewing_party_lite_7 [gg-solo-spike] $ 
```